### PR TITLE
Forcing edge mode

### DIFF
--- a/lib/outliner.ts
+++ b/lib/outliner.ts
@@ -65,6 +65,7 @@ export function outline(mapFile: string, outFile: string): void {
         writer
             .writeln('<head>')
                 .indent()
+                .writeln('<meta http-equiv="X-UA-Compatible" content="IE=edge" />')
                 .writeln('<style>')
                     .suspendIndenting()
                     .writeln(utils.readFile(stylePath))


### PR DESCRIPTION
This change adds the meta tag for forcing IE into edge mode. This
overcomes the problem of hosting the files on an intranet server that
causes IE to run in a legacy document mode which doesn't support the
features needed to render the page.
